### PR TITLE
Fix use of invisible with return

### DIFF
--- a/R/util_plots.R
+++ b/R/util_plots.R
@@ -464,5 +464,5 @@ plot_ar <- function(x, highlight = NULL, pos = NULL, legend = TRUE, ...){
                     bg = "gray90",
                     cex = 0.5)
 
-  invisible(return(x)) ## to allow it to be used within pipes - still prints though...
+  return(invisible(x)) ## to allow it to be used within pipes
 }


### PR DESCRIPTION
Hi, I just randomly stumbled upon this comment. I believe what happens is that `invisible` evaluates its argument eagerly, and since the argument calls `return`, the function is immediately left without changing the visibility. See below:
```
f <- function() invisible(return(5))
f()
## [1] 5
f <- function() return(invisible(5))
f()
## 
```